### PR TITLE
Add resource filters and bilingual toggle to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,89 +13,268 @@
 <body>
     <div class="container">
         <header class="header">
-            <h1 class="main-title" aria-label="Mis Herramientas de ELE">
-                <span class="title-word">
-                    <span class="title-letter">M</span>
-                    <span class="title-letter">i</span>
-                    <span class="title-letter">s</span>
-                </span>
-                <span class="title-letter space" aria-hidden="true"> </span>
-                <span class="title-word">
-                    <span class="title-letter">H</span>
-                    <span class="title-letter">e</span>
-                    <span class="title-letter">r</span>
-                    <span class="title-letter">r</span>
-                    <span class="title-letter">a</span>
-                    <span class="title-letter">m</span>
-                    <span class="title-letter">i</span>
-                    <span class="title-letter">e</span>
-                    <span class="title-letter">n</span>
-                    <span class="title-letter">t</span>
-                    <span class="title-letter">a</span>
-                    <span class="title-letter">s</span>
-                </span>
-                <span class="title-letter space" aria-hidden="true"> </span>
-                <span class="title-word">
-                    <span class="title-letter">d</span>
-                    <span class="title-letter">e</span>
-                </span>
-                <span class="title-letter space" aria-hidden="true"> </span>
-                <span class="title-word">
-                    <span class="title-letter">E</span>
-                    <span class="title-letter">L</span>
-                    <span class="title-letter">E</span>
-                </span>
-            </h1>
-            <p class="subtitle">Una colección creciente de minijuegos para practicar español paso a paso.</p>
+            <div class="header-actions">
+                <div class="language-toggle">
+                    <button class="lang-btn" type="button" aria-label="Cambiar a inglés">English</button>
+                </div>
+            </div>
+            <h1 class="main-title">Mis Herramientas de ELE</h1>
+            <p class="subtitle" data-i18n-key="subtitle">Una colección creciente de minijuegos para practicar español paso a paso.</p>
         </header>
 
+        <section class="controls" aria-label="Controles de filtrado">
+            <div class="filters" role="toolbar" aria-label="Filtros de recursos">
+                <span class="filter-label" data-i18n-key="filterLabel">Filtrar por tipo</span>
+                <div class="filter-buttons" role="group" aria-label="Tipos de recurso">
+                    <button class="filter-btn active" type="button" data-filter="all" aria-pressed="true" data-i18n-key="filterAll">Todos</button>
+                    <button class="filter-btn" type="button" data-filter="exercise" aria-pressed="false" data-i18n-key="filterExercises">Ejercicios</button>
+                    <button class="filter-btn" type="button" data-filter="reading" aria-pressed="false" data-i18n-key="filterReadings">Lecturas</button>
+                    <button class="filter-btn" type="button" data-filter="game" aria-pressed="false" data-i18n-key="filterGames">Juegos</button>
+                </div>
+            </div>
+        </section>
+
         <main class="tools-grid grid-view">
-            <article class="tool-card">
+            <article class="tool-card" data-category="exercise">
                 <div class="tool-header">
                     <div>
-                        <h3 class="tool-title">Conjugador de "ser"</h3>
+                        <h3 class="tool-title" data-i18n-key="serTitle">Conjugador de "ser"</h3>
                         <div class="tool-meta">
-                            <span>Gramática interactiva</span>
-                            <span>Niveles A1 – A2</span>
+                            <span data-i18n-key="serMeta1">Gramática interactiva</span>
+                            <span data-i18n-key="serMeta2">Niveles A1 – A2</span>
                         </div>
                     </div>
                 </div>
-                <p class="tool-description">Practica las formas del verbo <em>ser</em> en presente, pasado y futuro con pistas visuales y autoevaluación inmediata.</p>
+                <p class="tool-description" data-i18n-key="serDescription" data-i18n-mode="html">Practica las formas del verbo <em>ser</em> en presente, pasado y futuro con pistas visuales y autoevaluación inmediata.</p>
                 <div class="tool-tags">
-                    <span class="tag subject">Gramática</span>
-                    <span class="tag level">A1-A2</span>
+                    <span class="tag subject" data-i18n-key="serTagSubject">Gramática</span>
+                    <span class="tag level" data-i18n-key="serTagLevel">A1-A2</span>
                 </div>
                 <div class="tool-footer">
-                    <a class="visit-btn" href="herramientas/conjugador-ser/Conjugaciónser2.html">Jugar ahora</a>
-                    <p class="usage-count">Duración aprox.: 10 minutos</p>
+                    <a class="visit-btn" href="herramientas/conjugador-ser/Conjugaciónser2.html" data-i18n-key="serButton">Jugar ahora</a>
+                    <p class="usage-count" data-i18n-key="serDuration">Duración aprox.: 10 minutos</p>
                 </div>
             </article>
 
-            <article class="tool-card">
+            <article class="tool-card" data-category="game">
                 <div class="tool-header">
                     <div>
-                        <h3 class="tool-title">Clasificador de sustantivos</h3>
+                        <h3 class="tool-title" data-i18n-key="nounsTitle">Clasificador de sustantivos</h3>
                         <div class="tool-meta">
-                            <span>Vocabulario temático</span>
-                            <span>Niveles A1 – A2</span>
+                            <span data-i18n-key="nounsMeta1">Vocabulario temático</span>
+                            <span data-i18n-key="nounsMeta2">Niveles A1 – A2</span>
                         </div>
                     </div>
                 </div>
-                <p class="tool-description">Arrastra y suelta cada palabra en la categoría correcta para repasar géneros, temas y traducciones básicas.</p>
+                <p class="tool-description" data-i18n-key="nounsDescription">Arrastra y suelta cada palabra en la categoría correcta para repasar géneros, temas y traducciones básicas.</p>
                 <div class="tool-tags">
-                    <span class="tag subject">Vocabulario</span>
-                    <span class="tag level">A1-A2</span>
+                    <span class="tag subject" data-i18n-key="nounsTagSubject">Vocabulario</span>
+                    <span class="tag level" data-i18n-key="nounsTagLevel">A1-A2</span>
                 </div>
                 <div class="tool-footer">
-                    <a class="visit-btn" href="herramientas/clasificador-sustantivos/nouns.html">Descubrir</a>
-                    <p class="usage-count">Ideal para repasar en clase o en casa</p>
+                    <a class="visit-btn" href="herramientas/clasificador-sustantivos/nouns.html" data-i18n-key="nounsButton">Descubrir</a>
+                    <p class="usage-count" data-i18n-key="nounsDuration">Ideal para repasar en clase o en casa</p>
                 </div>
             </article>
         </main>
 
+        <div class="empty-state" data-i18n-key="noResults" hidden>
+            No hay recursos disponibles para este filtro todavía. ¡Pronto habrá más!
+        </div>
+
         <footer class="footer">
-            <p>Creado con ❤️ para mis estudiantes de español.</p>
+            <p class="footer-text" data-i18n-key="footer">Creado con ❤️ para mis estudiantes de español.</p>
         </footer>
     </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const translations = {
+                es: {
+                    mainTitle: 'Mis Herramientas de ELE',
+                    subtitle: 'Una colección creciente de minijuegos para practicar español paso a paso.',
+                    filterLabel: 'Filtrar por tipo',
+                    filterAll: 'Todos',
+                    filterExercises: 'Ejercicios',
+                    filterReadings: 'Lecturas',
+                    filterGames: 'Juegos',
+                    noResults: 'No hay recursos disponibles para este filtro todavía. ¡Pronto habrá más!',
+                    serTitle: 'Conjugador de "ser"',
+                    serMeta1: 'Gramática interactiva',
+                    serMeta2: 'Niveles A1 – A2',
+                    serDescription: 'Practica las formas del verbo <em>ser</em> en presente, pasado y futuro con pistas visuales y autoevaluación inmediata.',
+                    serTagSubject: 'Gramática',
+                    serTagLevel: 'A1-A2',
+                    serButton: 'Jugar ahora',
+                    serDuration: 'Duración aprox.: 10 minutos',
+                    nounsTitle: 'Clasificador de sustantivos',
+                    nounsMeta1: 'Vocabulario temático',
+                    nounsMeta2: 'Niveles A1 – A2',
+                    nounsDescription: 'Arrastra y suelta cada palabra en la categoría correcta para repasar géneros, temas y traducciones básicas.',
+                    nounsTagSubject: 'Vocabulario',
+                    nounsTagLevel: 'A1-A2',
+                    nounsButton: 'Descubrir',
+                    nounsDuration: 'Ideal para repasar en clase o en casa',
+                    footer: 'Creado con ❤️ para mis estudiantes de español.',
+                    languageButton: 'English',
+                    languageButtonAria: 'Cambiar a inglés'
+                },
+                en: {
+                    mainTitle: 'My ELE Toolkit',
+                    subtitle: 'A growing collection of mini games to practice Spanish step by step.',
+                    filterLabel: 'Filter by type',
+                    filterAll: 'All',
+                    filterExercises: 'Exercises',
+                    filterReadings: 'Readings',
+                    filterGames: 'Games',
+                    noResults: 'No resources match this filter yet. More activities are coming soon!',
+                    serTitle: '"Ser" conjugator',
+                    serMeta1: 'Interactive grammar',
+                    serMeta2: 'Levels A1 – A2',
+                    serDescription: 'Practice the verb <em>ser</em> in the present, past, and future with visual clues and instant feedback.',
+                    serTagSubject: 'Grammar',
+                    serTagLevel: 'A1-A2',
+                    serButton: 'Play now',
+                    serDuration: 'Approx. duration: 10 minutes',
+                    nounsTitle: 'Noun classifier',
+                    nounsMeta1: 'Thematic vocabulary',
+                    nounsMeta2: 'Levels A1 – A2',
+                    nounsDescription: 'Drag and drop each word into the correct category to review gender, themes, and basic translations.',
+                    nounsTagSubject: 'Vocabulary',
+                    nounsTagLevel: 'A1-A2',
+                    nounsButton: 'Explore',
+                    nounsDuration: 'Perfect for reviewing in class or at home',
+                    footer: 'Created with ❤️ for my Spanish students.',
+                    languageButton: 'Español',
+                    languageButtonAria: 'Switch to Spanish'
+                }
+            };
+
+            const state = {
+                lang: 'es',
+                filter: 'all'
+            };
+
+            const titleEl = document.querySelector('.main-title');
+            const langToggle = document.querySelector('.lang-btn');
+            const filterButtons = document.querySelectorAll('.filter-btn');
+            const toolCards = document.querySelectorAll('.tool-card');
+            const emptyState = document.querySelector('.empty-state');
+            const i18nElements = document.querySelectorAll('[data-i18n-key]');
+
+            const renderTitle = (text) => {
+                if (!titleEl) return;
+                titleEl.innerHTML = '';
+                titleEl.setAttribute('aria-label', text);
+
+                const words = text.split(' ');
+                words.forEach((word, wordIndex) => {
+                    const wordSpan = document.createElement('span');
+                    wordSpan.className = 'title-word';
+
+                    Array.from(word).forEach((char) => {
+                        const letterSpan = document.createElement('span');
+                        letterSpan.className = 'title-letter';
+                        letterSpan.textContent = char;
+                        wordSpan.appendChild(letterSpan);
+                    });
+
+                    titleEl.appendChild(wordSpan);
+
+                    if (wordIndex < words.length - 1) {
+                        const spaceSpan = document.createElement('span');
+                        spaceSpan.className = 'title-letter space';
+                        spaceSpan.setAttribute('aria-hidden', 'true');
+                        spaceSpan.textContent = ' ';
+                        titleEl.appendChild(spaceSpan);
+                    }
+                });
+            };
+
+            const applyTranslations = () => {
+                const copy = translations[state.lang];
+                if (!copy) return;
+
+                renderTitle(copy.mainTitle);
+
+                i18nElements.forEach((el) => {
+                    const key = el.dataset.i18nKey;
+                    if (!key || !copy[key]) {
+                        return;
+                    }
+
+                    if (key === 'mainTitle') {
+                        return;
+                    }
+
+                    const mode = el.dataset.i18nMode || 'text';
+                    if (mode === 'html') {
+                        el.innerHTML = copy[key];
+                    } else {
+                        el.textContent = copy[key];
+                    }
+                });
+
+                if (langToggle) {
+                    langToggle.textContent = copy.languageButton;
+                    langToggle.setAttribute('aria-label', copy.languageButtonAria);
+                }
+
+                if (emptyState && copy.noResults) {
+                    emptyState.innerHTML = copy.noResults;
+                }
+
+                document.documentElement.lang = state.lang;
+                document.documentElement.dataset.lang = state.lang;
+            };
+
+            const applyFilter = () => {
+                let visibleCount = 0;
+
+                toolCards.forEach((card) => {
+                    const categories = (card.dataset.category || '').split(/\s+/).filter(Boolean);
+                    const matches = state.filter === 'all' || categories.includes(state.filter);
+
+                    card.classList.toggle('is-hidden', !matches);
+
+                    if (matches) {
+                        visibleCount += 1;
+                    }
+                });
+
+                if (emptyState) {
+                    if (visibleCount === 0) {
+                        emptyState.hidden = false;
+                    } else {
+                        emptyState.hidden = true;
+                    }
+                }
+            };
+
+            filterButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    state.filter = button.dataset.filter || 'all';
+
+                    filterButtons.forEach((btn) => {
+                        const isActive = btn === button;
+                        btn.classList.toggle('active', isActive);
+                        btn.setAttribute('aria-pressed', String(isActive));
+                    });
+
+                    applyFilter();
+                });
+            });
+
+            if (langToggle) {
+                langToggle.addEventListener('click', () => {
+                    state.lang = state.lang === 'es' ? 'en' : 'es';
+                    applyTranslations();
+                });
+            }
+
+            applyTranslations();
+            applyFilter();
+        });
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -226,6 +226,68 @@ body {
     margin-bottom: 20px;
 }
 
+.header-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
+}
+
+.filter-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.filter-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.filter-btn {
+    padding: 10px 18px;
+    border-radius: 25px;
+    border: 2px solid transparent;
+    background: rgba(0, 140, 69, 0.12);
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    letter-spacing: 0.3px;
+}
+
+.filter-btn:hover {
+    transform: translateY(-1px);
+    border-color: #008c45;
+}
+
+.filter-btn:focus-visible {
+    outline: 3px solid rgba(0, 140, 69, 0.35);
+    outline-offset: 2px;
+}
+
+.filter-btn.active {
+    background: linear-gradient(135deg, #008c45 0%, #006837 100%);
+    color: white;
+    box-shadow: 0 10px 20px rgba(0, 140, 69, 0.2);
+}
+
+.tool-card.is-hidden {
+    display: none;
+}
+
+.empty-state {
+    padding: 40px 30px 60px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-weight: 500;
+    background: var(--bg-secondary);
+    border-top: 1px solid var(--border-light);
+}
+
+.empty-state[hidden] {
+    display: none !important;
+}
+
 .filter-group {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add a filter toolbar so visitors can view resources by activity type
- introduce an English/Spanish toggle and translation handling for homepage copy
- style the new controls and empty state to match the existing aesthetic

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e60d8e57888327a3cf6ad7aff518f6