### PR TITLE
Render tools dynamically from JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,53 +34,9 @@
             </div>
         </section>
 
-        <main class="tools-grid grid-view">
-            <article class="tool-card" data-category="exercise">
-                <div class="tool-header">
-                    <div>
-                        <h3 class="tool-title" data-i18n-key="serTitle">Conjugador de "ser"</h3>
-                        <div class="tool-meta">
-                            <span data-i18n-key="serMeta1">Gramática interactiva</span>
-                            <span data-i18n-key="serMeta2">Niveles A1 – A2</span>
-                        </div>
-                    </div>
-                </div>
-                <p class="tool-description" data-i18n-key="serDescription" data-i18n-mode="html">Practica las formas del verbo <em>ser</em> en presente, pasado y futuro con pistas visuales y autoevaluación inmediata.</p>
-                <div class="tool-tags">
-                    <span class="tag subject" data-i18n-key="serTagSubject">Gramática</span>
-                    <span class="tag level" data-i18n-key="serTagLevel">A1-A2</span>
-                </div>
-                <div class="tool-footer">
-                    <a class="visit-btn" href="herramientas/conjugador-ser/Conjugaciónser2.html" data-i18n-key="serButton">Jugar ahora</a>
-                    <p class="usage-count" data-i18n-key="serDuration">Duración aprox.: 10 minutos</p>
-                </div>
-            </article>
+        <main class="tools-grid grid-view"></main>
 
-            <article class="tool-card" data-category="game">
-                <div class="tool-header">
-                    <div>
-                        <h3 class="tool-title" data-i18n-key="nounsTitle">Clasificador de sustantivos</h3>
-                        <div class="tool-meta">
-                            <span data-i18n-key="nounsMeta1">Vocabulario temático</span>
-                            <span data-i18n-key="nounsMeta2">Niveles A1 – A2</span>
-                        </div>
-                    </div>
-                </div>
-                <p class="tool-description" data-i18n-key="nounsDescription">Arrastra y suelta cada palabra en la categoría correcta para repasar géneros, temas y traducciones básicas.</p>
-                <div class="tool-tags">
-                    <span class="tag subject" data-i18n-key="nounsTagSubject">Vocabulario</span>
-                    <span class="tag level" data-i18n-key="nounsTagLevel">A1-A2</span>
-                </div>
-                <div class="tool-footer">
-                    <a class="visit-btn" href="herramientas/clasificador-sustantivos/nouns.html" data-i18n-key="nounsButton">Descubrir</a>
-                    <p class="usage-count" data-i18n-key="nounsDuration">Ideal para repasar en clase o en casa</p>
-                </div>
-            </article>
-        </main>
-
-        <div class="empty-state" data-i18n-key="noResults" hidden>
-            No hay recursos disponibles para este filtro todavía. ¡Pronto habrá más!
-        </div>
+        <div class="empty-state" hidden></div>
 
         <footer class="footer">
             <p class="footer-text" data-i18n-key="footer">Creado con ❤️ para mis estudiantes de español.</p>
@@ -99,22 +55,11 @@
                     filterReadings: 'Lecturas',
                     filterGames: 'Juegos',
                     noResults: 'No hay recursos disponibles para este filtro todavía. ¡Pronto habrá más!',
-                    serTitle: 'Conjugador de "ser"',
-                    serMeta1: 'Gramática interactiva',
-                    serMeta2: 'Niveles A1 – A2',
-                    serDescription: 'Practica las formas del verbo <em>ser</em> en presente, pasado y futuro con pistas visuales y autoevaluación inmediata.',
-                    serTagSubject: 'Gramática',
-                    serTagLevel: 'A1-A2',
-                    serButton: 'Jugar ahora',
-                    serDuration: 'Duración aprox.: 10 minutos',
-                    nounsTitle: 'Clasificador de sustantivos',
-                    nounsMeta1: 'Vocabulario temático',
-                    nounsMeta2: 'Niveles A1 – A2',
-                    nounsDescription: 'Arrastra y suelta cada palabra en la categoría correcta para repasar géneros, temas y traducciones básicas.',
-                    nounsTagSubject: 'Vocabulario',
-                    nounsTagLevel: 'A1-A2',
-                    nounsButton: 'Descubrir',
-                    nounsDuration: 'Ideal para repasar en clase o en casa',
+                    loading: 'Cargando recursos...',
+                    loadError: 'No se pudieron cargar los recursos. Inténtalo de nuevo más tarde.',
+                    visitButton: 'Abrir recurso',
+                    addedOn: 'Añadido:',
+                    coursesLabel: 'Cursos:',
                     footer: 'Creado con ❤️ para mis estudiantes de español.',
                     languageButton: 'English',
                     languageButtonAria: 'Cambiar a inglés'
@@ -128,22 +73,11 @@
                     filterReadings: 'Readings',
                     filterGames: 'Games',
                     noResults: 'No resources match this filter yet. More activities are coming soon!',
-                    serTitle: '"Ser" conjugator',
-                    serMeta1: 'Interactive grammar',
-                    serMeta2: 'Levels A1 – A2',
-                    serDescription: 'Practice the verb <em>ser</em> in the present, past, and future with visual clues and instant feedback.',
-                    serTagSubject: 'Grammar',
-                    serTagLevel: 'A1-A2',
-                    serButton: 'Play now',
-                    serDuration: 'Approx. duration: 10 minutes',
-                    nounsTitle: 'Noun classifier',
-                    nounsMeta1: 'Thematic vocabulary',
-                    nounsMeta2: 'Levels A1 – A2',
-                    nounsDescription: 'Drag and drop each word into the correct category to review gender, themes, and basic translations.',
-                    nounsTagSubject: 'Vocabulary',
-                    nounsTagLevel: 'A1-A2',
-                    nounsButton: 'Explore',
-                    nounsDuration: 'Perfect for reviewing in class or at home',
+                    loading: 'Loading resources...',
+                    loadError: 'We could not load the resources. Please try again later.',
+                    visitButton: 'Open resource',
+                    addedOn: 'Added:',
+                    coursesLabel: 'Courses:',
                     footer: 'Created with ❤️ for my Spanish students.',
                     languageButton: 'Español',
                     languageButtonAria: 'Switch to Spanish'
@@ -152,13 +86,23 @@
 
             const state = {
                 lang: 'es',
-                filter: 'all'
+                filter: 'all',
+                tools: [],
+                isLoading: true,
+                error: false
+            };
+
+            const CATEGORY_MAP = {
+                game: 'game',
+                resource: 'reading',
+                'interactive practice': 'exercise',
+                'interactive activity': 'exercise'
             };
 
             const titleEl = document.querySelector('.main-title');
             const langToggle = document.querySelector('.lang-btn');
             const filterButtons = document.querySelectorAll('.filter-btn');
-            const toolCards = document.querySelectorAll('.tool-card');
+            const toolsGrid = document.querySelector('.tools-grid');
             const emptyState = document.querySelector('.empty-state');
             const i18nElements = document.querySelectorAll('[data-i18n-key]');
 
@@ -191,19 +135,192 @@
                 });
             };
 
+            const formatDate = (isoDate) => {
+                if (!isoDate) {
+                    return '';
+                }
+
+                const date = new Date(isoDate);
+                if (Number.isNaN(date.getTime())) {
+                    return '';
+                }
+
+                return new Intl.DateTimeFormat(state.lang, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
+                }).format(date);
+            };
+
+            const getCategoryFromTool = (tool) => {
+                const typeValue = (tool?.type?.en || tool?.type?.es || '').toLowerCase().trim();
+                return CATEGORY_MAP[typeValue] || 'exercise';
+            };
+
+            const createToolCard = (tool) => {
+                const copy = translations[state.lang];
+                const subjects = tool?.subjects?.[state.lang] || tool?.subjects?.en || [];
+                const card = document.createElement('article');
+                card.className = 'tool-card';
+                card.dataset.category = getCategoryFromTool(tool);
+
+                const header = document.createElement('div');
+                header.className = 'tool-header';
+
+                const headerInfo = document.createElement('div');
+
+                const title = document.createElement('h3');
+                title.className = 'tool-title';
+                title.textContent = tool?.title || '';
+
+                const meta = document.createElement('div');
+                meta.className = 'tool-meta';
+
+                const typeSpan = document.createElement('span');
+                typeSpan.className = 'tool-type';
+                typeSpan.textContent = tool?.type?.[state.lang] || tool?.type?.en || '';
+                if (typeSpan.textContent) {
+                    meta.appendChild(typeSpan);
+                }
+
+                const formattedDate = formatDate(tool?.dateAdded);
+                if (formattedDate) {
+                    const dateSpan = document.createElement('span');
+                    dateSpan.className = 'tool-date';
+                    dateSpan.textContent = `${translations[state.lang].addedOn} ${formattedDate}`;
+                    meta.appendChild(dateSpan);
+                }
+
+                headerInfo.appendChild(title);
+                if (meta.childNodes.length > 0) {
+                    headerInfo.appendChild(meta);
+                }
+
+                header.appendChild(headerInfo);
+                card.appendChild(header);
+
+                if (tool?.description) {
+                    const description = document.createElement('p');
+                    description.className = 'tool-description';
+                    description.innerHTML = tool.description[state.lang] || tool.description.en || '';
+                    card.appendChild(description);
+                }
+
+                if (Array.isArray(subjects) && subjects.length > 0) {
+                    const tagsWrapper = document.createElement('div');
+                    tagsWrapper.className = 'tool-tags';
+
+                    const labelTag = document.createElement('span');
+                    labelTag.className = 'tag label';
+                    labelTag.textContent = copy.coursesLabel;
+                    tagsWrapper.appendChild(labelTag);
+
+                    subjects.forEach((subject) => {
+                        const subjectTag = document.createElement('span');
+                        subjectTag.className = 'tag subject';
+                        subjectTag.textContent = subject;
+                        tagsWrapper.appendChild(subjectTag);
+                    });
+
+                    card.appendChild(tagsWrapper);
+                }
+
+                const footer = document.createElement('div');
+                footer.className = 'tool-footer';
+
+                const visitBtn = document.createElement('a');
+                visitBtn.className = 'visit-btn';
+                visitBtn.href = tool?.link || '#';
+                visitBtn.target = '_blank';
+                visitBtn.rel = 'noopener noreferrer';
+                visitBtn.textContent = copy.visitButton;
+
+                footer.appendChild(visitBtn);
+                card.appendChild(footer);
+
+                return card;
+            };
+
+            const renderTools = () => {
+                if (!toolsGrid) {
+                    return;
+                }
+
+                toolsGrid.innerHTML = '';
+
+                const fragment = document.createDocumentFragment();
+                state.tools.forEach((tool) => {
+                    fragment.appendChild(createToolCard(tool));
+                });
+
+                toolsGrid.appendChild(fragment);
+            };
+
+            const updateEmptyState = (visibleCount = 0) => {
+                if (!emptyState) {
+                    return;
+                }
+
+                const copy = translations[state.lang];
+                if (!copy) {
+                    return;
+                }
+
+                if (state.isLoading) {
+                    emptyState.hidden = false;
+                    emptyState.textContent = copy.loading;
+                    return;
+                }
+
+                if (state.error) {
+                    emptyState.hidden = false;
+                    emptyState.textContent = copy.loadError;
+                    return;
+                }
+
+                if (!state.tools.length) {
+                    emptyState.hidden = false;
+                    emptyState.textContent = copy.noResults;
+                    return;
+                }
+
+                if (visibleCount === 0) {
+                    emptyState.hidden = false;
+                    emptyState.textContent = copy.noResults;
+                } else {
+                    emptyState.hidden = true;
+                }
+            };
+
+            const applyFilter = () => {
+                const cards = toolsGrid ? toolsGrid.querySelectorAll('.tool-card') : [];
+                let visibleCount = 0;
+
+                cards.forEach((card) => {
+                    const categories = (card.dataset.category || '').split(/\s+/).filter(Boolean);
+                    const matches = state.filter === 'all' || categories.includes(state.filter);
+
+                    card.classList.toggle('is-hidden', !matches);
+
+                    if (matches) {
+                        visibleCount += 1;
+                    }
+                });
+
+                updateEmptyState(visibleCount);
+            };
+
             const applyTranslations = () => {
                 const copy = translations[state.lang];
-                if (!copy) return;
+                if (!copy) {
+                    return;
+                }
 
                 renderTitle(copy.mainTitle);
 
                 i18nElements.forEach((el) => {
                     const key = el.dataset.i18nKey;
-                    if (!key || !copy[key]) {
-                        return;
-                    }
-
-                    if (key === 'mainTitle') {
+                    if (!key || !(key in copy)) {
                         return;
                     }
 
@@ -220,35 +337,11 @@
                     langToggle.setAttribute('aria-label', copy.languageButtonAria);
                 }
 
-                if (emptyState && copy.noResults) {
-                    emptyState.innerHTML = copy.noResults;
-                }
-
                 document.documentElement.lang = state.lang;
                 document.documentElement.dataset.lang = state.lang;
-            };
 
-            const applyFilter = () => {
-                let visibleCount = 0;
-
-                toolCards.forEach((card) => {
-                    const categories = (card.dataset.category || '').split(/\s+/).filter(Boolean);
-                    const matches = state.filter === 'all' || categories.includes(state.filter);
-
-                    card.classList.toggle('is-hidden', !matches);
-
-                    if (matches) {
-                        visibleCount += 1;
-                    }
-                });
-
-                if (emptyState) {
-                    if (visibleCount === 0) {
-                        emptyState.hidden = false;
-                    } else {
-                        emptyState.hidden = true;
-                    }
-                }
+                renderTools();
+                applyFilter();
             };
 
             filterButtons.forEach((button) => {
@@ -272,8 +365,34 @@
                 });
             }
 
+            const fetchTools = async () => {
+                try {
+                    state.isLoading = true;
+                    state.error = false;
+                    updateEmptyState();
+
+                    const response = await fetch('tools.json');
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}`);
+                    }
+
+                    const data = await response.json();
+                    state.tools = Array.isArray(data?.tools) ? data.tools : [];
+                    state.isLoading = false;
+                    state.error = false;
+                } catch (error) {
+                    console.error('Error loading tools:', error);
+                    state.tools = [];
+                    state.isLoading = false;
+                    state.error = true;
+                }
+
+                renderTools();
+                applyFilter();
+            };
+
             applyTranslations();
-            applyFilter();
+            fetchTools();
         });
     </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -536,6 +536,25 @@ body:not([data-theme="dark"]) .moon-icon {
     gap: 3px;
 }
 
+.tool-type {
+    font-weight: 600;
+    color: #006837;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+}
+
+.tool-date {
+    color: var(--text-muted);
+}
+
+[data-theme="dark"] .tool-type {
+    color: #4caf50;
+}
+
+[data-theme="dark"] .tool-date {
+    color: var(--text-secondary);
+}
+
 .tool-description {
     color: var(--text-secondary);
     line-height: 1.6;
@@ -560,6 +579,12 @@ body:not([data-theme="dark"]) .moon-icon {
     border: 1px solid rgba(0, 140, 69, 0.2);
 }
 
+.tag.label {
+    background: rgba(0, 140, 69, 0.05);
+    color: #006837;
+    border-style: dashed;
+}
+
 .tag.subject {
     background: rgba(200, 16, 46, 0.1);
     color: #c8102e;
@@ -576,6 +601,11 @@ body:not([data-theme="dark"]) .moon-icon {
     background: rgba(0, 140, 69, 0.2);
     color: #4caf50;
     border: 1px solid rgba(0, 140, 69, 0.3);
+}
+
+[data-theme="dark"] .tag.label {
+    background: rgba(0, 140, 69, 0.15);
+    color: #4caf50;
 }
 
 [data-theme="dark"] .tag.subject {


### PR DESCRIPTION
## Summary
- render the tools grid from `tools.json` instead of hardcoding two entries
- add loading/error empty states and keep language toggle/filter behavior in sync with the data
- style the new metadata and course tags for the dynamically generated cards

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e60f57ed1483279c38afd2ef22d03e