### PR TITLE
Add Gramática A1 heading and video summary to nouns page

### DIFF
--- a/herramientas/clasificador-sustantivos/nouns.html
+++ b/herramientas/clasificador-sustantivos/nouns.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Understanding Nouns: Spanish vs. Chinese</title>
+    <title>Gramática A1</title>
     <style>
         /* Basic Styling */
         body {
@@ -21,6 +21,30 @@
             border-radius: 8px;
             box-shadow: 0 4px 12px rgba(0,0,0,0.1);
             overflow: hidden;
+        }
+
+        .page-title {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+
+        .video-wrapper {
+            position: relative;
+            padding-bottom: 56.25%;
+            height: 0;
+            overflow: hidden;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            margin-bottom: 30px;
+        }
+
+        .video-wrapper iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
         }
 
         /* Tab Navigation */
@@ -136,6 +160,10 @@
 <body>
 
     <div class="container">
+        <h1 class="page-title">Gramática A1</h1>
+        <div class="video-wrapper">
+            <iframe src="https://www.youtube.com/embed/S0LLn4I5ZN0" title="Resumen Gramática A1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
         <header class="tabs">
             <button class="tab-link active" onclick="openTab(event, 'Theory')">Teoría</button>
             <button class="tab-link" onclick="openTab(event, 'Exercise1')">Ejercicio 1: Cuantificación</button>


### PR DESCRIPTION
## Summary
- embed the Gramática A1 YouTube summary at the top of the nouns resource
- add styling and heading updates to present the new video prominently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6138383f08327b62e752a12d94da5